### PR TITLE
Fix Z1 ROM visualizer blue potion display bug

### DIFF
--- a/data_extractor.py
+++ b/data_extractor.py
@@ -263,7 +263,7 @@ class DataExtractor(object):
 
             if left_exit == room_num and right_exit == room_num:
                 # This is an item staircase, not a transport staircase
-                item_type = int(self.GetRoomData(level_num, stairway_room_num + (4 * 0x80)) % 0x1F)
+                item_type = int(self.GetRoomData(level_num, stairway_room_num + (4 * 0x80)) % 0x20)
                 self.data[level_num][left_exit]['stair_info'] = '%s' % ITEM_TYPES[item_type]
                 self.data[level_num][left_exit]['stair_tooltip'] = '%s' % ITEM_TYPES[item_type]
                 break


### PR DESCRIPTION
Changed modulo from 0x1F to 0x20 in item staircase code extraction. The item code range is 0x00-0x1F (32 items), so modulo should be 0x20. Previously, item code 0x1F would wrap to 0x00 (31 % 31 = 0).